### PR TITLE
toLowerCase() causes broken links in TOC for non-Latin symbols

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -28,7 +28,6 @@ export function log(msg: string, obj?) {
 
 export function slugify(heading: string) {
     let slug = heading.trim()
-        .toLowerCase()
         .replace(/[\]\[\!\"\#\$\%\&\'\(\)\*\+\,\.\/\:\;\<\=\>\?\@\\\^\_\{\|\}\~\`]/g, '')
         .replace(/\s+/g, '-')
         .replace(/^\-+/, '')


### PR DESCRIPTION
For example, string "Работа с переменными" becomes link "#работа-с-переменными", which doesn't work. In this case, correct link must be "#Работа-с-переменными" (capital letter at the beginning of the first word).